### PR TITLE
v25.9.23

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "25.2.10" %}
+{% set version = "25.9.23" %}
 
 package:
   name: flatbuffers
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://github.com/google/flatbuffers/archive/v{{ version }}.tar.gz
-  sha256: b9c2df49707c57a48fc0923d52b8c73beb72d675f9d44b2211e4569be40a7421
+  sha256: 9102253214dea6ae10c2ac966ea1ed2155d22202390b532d1dea64935c518ada
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,6 +18,7 @@ build:
 requirements:
   build:
     - cmake
+    - {{ stdlib('c') }}
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
     - ninja-base
@@ -33,7 +34,7 @@ test:
     - test -f ${PREFIX}/lib/libflatbuffers.so.{{ version }}                         # [linux]
 
 about:
-  home: https://google.github.io/flatbuffers/
+  home: https://flatbuffers.dev
   license: Apache-2.0
   license_file: LICENSE
   license_family: Apache
@@ -46,7 +47,7 @@ about:
     compatibility. It provides both memory efficiency and speed by allowing direct access to the 
     serialized data, and supports zero-copy deserialization.
   dev_url: https://github.com/google/flatbuffers 
-  doc_url: https://google.github.io/flatbuffers/
+  doc_url: https://flatbuffers.dev
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
flatbuffers v25.9.23

**Destination channel:** defaults

### Links

- [PKG-12949](https://anaconda.atlassian.net/browse/PKG-12949) 
- [Upstream repository](https://github.com/google/flatbuffers/tree/v25.9.23)
- Relevant PRs:
  - https://github.com/AnacondaRecipes/python-flatbuffers-feedstock/pull/2
  - https://github.com/AnacondaRecipes/tensorflow-feedstock/pull/22

### Explanation of changes:

- Bump version ans SHA
- Update metadata and fix linter


[PKG-12949]: https://anaconda.atlassian.net/browse/PKG-12949?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ